### PR TITLE
fix: add support for more rust reserved keywords

### DIFF
--- a/crates/rs/src/expand/struct.rs
+++ b/crates/rs/src/expand/struct.rs
@@ -26,6 +26,10 @@ impl CairoStruct {
             // TODO: this needs to be done more elegantly...
             if &inner.name == "type" {
                 members.push(quote!(r#type: #ty));
+            } else if &inner.name == "move" {
+                members.push(quote!(r#move: #ty));
+            } else if &inner.name == "final" {
+                members.push(quote!(r#final: #ty));
             } else {
                 members.push(quote!(#name: #ty));
             }
@@ -98,6 +102,32 @@ impl CairoStruct {
                 desers.push(quote! {
                     let r#type = #ty_punctuated::cairo_deserialize(__felts, __offset)?;
                     __offset += #ty_punctuated::cairo_serialized_size(&r#type);
+                });
+            } else if &inner.name == "move" {
+                names.push(quote!(r#move));
+
+                sizes.push(quote! {
+                    __size += #ty_punctuated::cairo_serialized_size(&__rust.r#move);
+                });
+
+                sers.push(quote!(__out.extend(#ty_punctuated::cairo_serialize(&__rust.r#move));));
+
+                desers.push(quote! {
+                    let r#move = #ty_punctuated::cairo_deserialize(__felts, __offset)?;
+                    __offset += #ty_punctuated::cairo_serialized_size(&r#move);
+                });
+            } else if &inner.name == "final" {
+                names.push(quote!(r#final));
+
+                sizes.push(quote! {
+                    __size += #ty_punctuated::cairo_serialized_size(&__rust.r#final);
+                });
+
+                sers.push(quote!(__out.extend(#ty_punctuated::cairo_serialize(&__rust.r#final));));
+
+                desers.push(quote! {
+                    let r#final = #ty_punctuated::cairo_deserialize(__felts, __offset)?;
+                    __offset += #ty_punctuated::cairo_serialized_size(&r#final);
                 });
             } else {
                 names.push(quote!(#name));


### PR DESCRIPTION
In namespaces of cairo types or structure fields, we may encounter some rust reserved keywords.

This PR is a first step to escape them, a more generic solution may be found to solve it more broadly.