### PR TITLE
struct.rs: add PartialOrd

### DIFF
--- a/crates/rs/src/expand/struct.rs
+++ b/crates/rs/src/expand/struct.rs
@@ -49,7 +49,7 @@ impl CairoStruct {
             // Those phantom fields are ignored by serde.
 
             quote! {
-                #[derive(Debug, PartialEq, PartialOrd, Clone)]
+                #[derive(Debug, PartialEq, Clone)]
                 pub struct #struct_name<#(#gen_args),*> {
                     #(pub #members),*
                 }


### PR DESCRIPTION
Added PartialOrd when generating struct to allow comparison operations (<, >, <=, >=).