### PR TITLE
feat: support LegacyContractClass to load ABI from artifacts

### DIFF
--- a/crates/rs/src/expand/function.rs
+++ b/crates/rs/src/expand/function.rs
@@ -154,6 +154,7 @@ impl CairoFunction {
                     }
 
                     #[allow(clippy::ptr_arg)]
+                    #[allow(clippy::too_many_arguments)]
                     pub fn #func_name_ident(
                         &self,
                         #(#inputs),*

--- a/examples/cairo0_account.rs
+++ b/examples/cairo0_account.rs
@@ -1,6 +1,10 @@
 use cainome::rs::abigen_legacy;
 
-abigen_legacy!(MyContract, "./contracts/cairo0/oz0.abi.json",);
+// From an extracted ABI.
+//abigen_legacy!(MyContract, "./contracts/cairo0/oz0.abi.json",);
+
+// From a LegacyContractClass extracting the ABI from it.
+abigen_legacy!(MyContract, "./contracts/cairo0/kkrt_account_cairo0.json");
 
 #[tokio::main]
 async fn main() {}


### PR DESCRIPTION
Avoid writing scripts to extract the ABI adding support to parse `LegacyContractClass` when working with Cairo 0.