### PR TITLE
fix: ensure composite inners are resolved to known types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,8 +1740,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.11.1"
-source = "git+https://github.com/kariy/starknet-rs?rev=fffe8e9#fffe8e9af69e73ac5a0925fe49266aa9198fff4a"
+version = "0.11.0"
+source = "git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch#d4a1e36699daa51587a1ef10f6b1549771d57a52"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto"
 version = "0.7.0"
-source = "git+https://github.com/kariy/starknet-rs?rev=fffe8e9#fffe8e9af69e73ac5a0925fe49266aa9198fff4a"
+source = "git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch#d4a1e36699daa51587a1ef10f6b1549771d57a52"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -1769,8 +1769,8 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen 0.4.0 (git+https://github.com/kariy/starknet-rs?rev=fffe8e9)",
- "starknet-curve 0.5.0 (git+https://github.com/kariy/starknet-rs?rev=fffe8e9)",
+ "starknet-crypto-codegen 0.4.0 (git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch)",
+ "starknet-curve 0.5.0 (git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch)",
  "starknet-types-core",
  "zeroize",
 ]
@@ -1809,9 +1809,9 @@ dependencies = [
 [[package]]
 name = "starknet-crypto-codegen"
 version = "0.4.0"
-source = "git+https://github.com/kariy/starknet-rs?rev=fffe8e9#fffe8e9af69e73ac5a0925fe49266aa9198fff4a"
+source = "git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch#d4a1e36699daa51587a1ef10f6b1549771d57a52"
 dependencies = [
- "starknet-curve 0.5.0 (git+https://github.com/kariy/starknet-rs?rev=fffe8e9)",
+ "starknet-curve 0.5.0 (git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch)",
  "starknet-types-core",
  "syn 2.0.68",
 ]
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "starknet-curve"
 version = "0.5.0"
-source = "git+https://github.com/kariy/starknet-rs?rev=fffe8e9#fffe8e9af69e73ac5a0925fe49266aa9198fff4a"
+source = "git+https://github.com/dojoengine/starknet-rs?branch=fix/include-patch#d4a1e36699daa51587a1ef10f6b1549771d57a52"
 dependencies = [
  "starknet-types-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,9 @@ url.workspace = true
 tokio = { version = "1.15.0", features = ["full"], optional = true }
 
 [patch.crates-io]
-# Remove this patch once the following PR is merged: <https://github.com/xJonathanLEI/starknet-rs/pull/615>
-# To enable std feature on `starknet-types-core`.
-starknet-core = { git = "https://github.com/kariy/starknet-rs", rev = "fffe8e9" }
+# Remove this patch once starknet-rs and types-core new revs in
+# <https://github.com/cartridge-gg/cainome/pull/44> are supported by Dojo.
+starknet-core = { git = "https://github.com/dojoengine/starknet-rs", branch = "fix/include-patch" }
 
 [features]
 default = []

--- a/crates/parser/src/abi/parser.rs
+++ b/crates/parser/src/abi/parser.rs
@@ -347,6 +347,32 @@ impl AbiParser {
             }
         }
 
+        // Can be a very huge copy here. Need an other way to do that in the loop
+        // above here.
+        let filtered = tokens_filtered.clone();
+
+        // So now once it's filtered, we may actually iterate again on the tokens
+        // to resolve all structs/enums inners that may reference existing types.
+        for (name, tokens) in tokens_filtered.iter_mut() {
+            if let Token::Composite(ref mut composite) = tokens {
+                for inner in &mut composite.inners {
+                    if let Token::Composite(ref mut inner_composite) = inner.token {
+                        if inner_composite.r#type == CompositeType::Unknown {
+                            inner.token = filtered
+                                .get(&inner.token.type_path())
+                                .expect(&format!(
+                                    "In composite {} the inner token type for {} is expected to exist: {}",
+                                    name,
+                                    inner.name,
+                                    inner.token.type_path()
+                                ))
+                                .clone();
+                        }
+                    }
+                }
+            }
+        }
+
         tokens_filtered
     }
 }

--- a/crates/parser/src/abi/parser.rs
+++ b/crates/parser/src/abi/parser.rs
@@ -360,8 +360,7 @@ impl AbiParser {
                         if inner_composite.r#type == CompositeType::Unknown {
                             inner.token = filtered
                                 .get(&inner.token.type_path())
-                                .expect(&format!(
-                                    "In composite {} the inner token type for {} is expected to exist: {}",
+                                .unwrap_or_else(|| panic!("In composite {} the inner token type for {} is expected to exist: {}",
                                     name,
                                     inner.name,
                                     inner.token.type_path()


### PR DESCRIPTION
Ensures that any composite inner is resolved to parsed struct/enums when it applies.