### PR TITLE
feat!: add custom derives from user

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -19,6 +19,7 @@ generate_artifacts:
 	jq .abi ${scarb_build}simple_interface${sierra} > ${artifacts}simple_interface.abi.json
 	jq .abi ${scarb_build}structs${sierra} > ${artifacts}structs.abi.json
 	jq .abi ${scarb_build}byte_array${sierra} > ${artifacts}byte_array.abi.json
+	jq .abi ${scarb_build}gen${sierra} > ${artifacts}gen.abi.json
 
 generate_rust:
 	scarb build
@@ -50,11 +51,14 @@ setup_byte_array:
 # 	starkli declare target/dev/contracts_basic.sierra.json ${config}
 # 	starkli deploy ${class_hash} --salt 0x1234 ${config}
 
-# # Declare and deploy the basic contract on katana.
-# setup_gen:
-# 	$(eval class_hash=$(shell starkli class-hash target/dev/contracts_gen.sierra.json))
-# 	starkli declare target/dev/contracts_gen.sierra.json ${config}
-# 	starkli deploy ${class_hash} --salt 0x1234 ${config}
+# Declare and deploy the basic contract on katana.
+setup_gen:
+	@set -x; \
+	scarb build; \
+	class_hash=$$(starkli class-hash ${scarb_build}gen${sierra}); \
+	starkli declare ${scarb_build}gen${sierra} ${config}; \
+	sleep 2; \
+	starkli deploy "$${class_hash}" --salt 0x1234 ${config}
 
 # # Declare and deploy the event contract on katana.
 # setup_event:

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -11,3 +11,4 @@ mod abicov {
 
 mod simple_get_set;
 mod basic;
+mod gen;

--- a/crates/rs-macro/src/lib.rs
+++ b/crates/rs-macro/src/lib.rs
@@ -33,6 +33,7 @@ fn abigen_internal(input: TokenStream) -> TokenStream {
         &contract_name.to_string(),
         &abi_tokens,
         contract_abi.execution_version,
+        &contract_abi.derives,
     );
 
     if let Some(out_path) = contract_abi.output_path {
@@ -61,6 +62,7 @@ fn abigen_internal_legacy(input: TokenStream) -> TokenStream {
         &contract_name.to_string(),
         &abi_tokens,
         cainome_rs::ExecutionVersion::V1,
+        &[],
     );
 
     if let Some(out_path) = contract_abi.output_path {

--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -37,6 +37,7 @@ pub(crate) struct ContractAbi {
     pub output_path: Option<String>,
     pub type_aliases: HashMap<String, String>,
     pub execution_version: ExecutionVersion,
+    pub derives: Vec<String>,
 }
 
 impl Parse for ContractAbi {
@@ -89,6 +90,7 @@ impl Parse for ContractAbi {
         let mut output_path: Option<String> = None;
         let mut execution_version = ExecutionVersion::V1;
         let mut type_aliases = HashMap::new();
+        let mut derives = Vec::new();
 
         loop {
             if input.parse::<Token![,]>().is_err() {
@@ -135,6 +137,15 @@ impl Parse for ContractAbi {
                         syn::Error::new(content.span(), format!("Invalid execution version: {}", e))
                     })?;
                 }
+                "derives" => {
+                    let content;
+                    parenthesized!(content in input);
+                    let parsed = content.parse_terminated(Spanned::<Type>::parse, Token![,])?;
+
+                    for derive in parsed {
+                        derives.push(derive.to_token_stream().to_string());
+                    }
+                }
                 _ => panic!("unexpected named parameter `{}`", name),
             }
         }
@@ -145,6 +156,7 @@ impl Parse for ContractAbi {
             output_path,
             type_aliases,
             execution_version,
+            derives,
         })
     }
 }

--- a/examples/structs.rs
+++ b/examples/structs.rs
@@ -1,0 +1,22 @@
+use cainome::rs::abigen;
+
+use starknet::core::types::Felt;
+
+abigen!(
+    MyContract,
+    "./contracts/abi/gen.abi.json",
+    derives(Debug, Clone)
+);
+
+#[tokio::main]
+async fn main() {
+    let s = MyStruct::<Felt> {
+        f1: Felt::ONE,
+        f2: Felt::TWO,
+        f3: Felt::THREE,
+    };
+
+    println!("{:?}", s);
+
+    let _s2 = s.clone();
+}

--- a/src/bin/cli/args.rs
+++ b/src/bin/cli/args.rs
@@ -62,6 +62,11 @@ pub struct CainomeArgs {
     #[arg(value_name = "EXECUTION_VERSION")]
     #[arg(help = "The execution version to use. Supported values are 'v1', 'V1', 'v3', or 'V3'.")]
     pub execution_version: ExecutionVersion,
+
+    #[arg(long)]
+    #[arg(value_name = "DERIVES")]
+    #[arg(help = "Derives to be added to the generated types.")]
+    pub derives: Option<Vec<String>>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/src/bin/cli/main.rs
+++ b/src/bin/cli/main.rs
@@ -52,6 +52,7 @@ async fn main() -> CainomeCliResult<()> {
         output_dir: args.output_dir,
         contracts,
         execution_version: args.execution_version,
+        derives: args.derives.unwrap_or_default(),
     })
     .await?;
 

--- a/src/bin/cli/plugins/builtins/rust.rs
+++ b/src/bin/cli/plugins/builtins/rust.rs
@@ -36,6 +36,7 @@ impl BuiltinPlugin for RustPlugin {
                 &contract_name,
                 &contract.tokens,
                 input.execution_version,
+                &input.derives,
             );
             let filename = format!(
                 "{}.rs",

--- a/src/bin/cli/plugins/mod.rs
+++ b/src/bin/cli/plugins/mod.rs
@@ -13,6 +13,7 @@ pub struct PluginInput {
     pub output_dir: Utf8PathBuf,
     pub contracts: Vec<ContractData>,
     pub execution_version: ExecutionVersion,
+    pub derives: Vec<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Now by default cainome doesn't add any derive to generated types. They must be passed by the user using `derives(Trait1, Trait2)`.

BREAKING CHANGE: breaking if downstream users rely on previously derived trait.