### PR TITLE
feat: error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly]
+        toolchain: [stable]
 
     steps:
       - name: Checkout source code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,12 +296,14 @@ dependencies = [
  "cainome-cairo-serde",
  "cainome-parser",
  "cainome-rs",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde_json",
  "starknet",
  "syn 2.0.68",
  "thiserror",
+ "trybuild",
 ]
 
 [[package]]
@@ -712,6 +714,12 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1270,7 +1278,31 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1581,6 +1613,15 @@ checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
  "serde",
 ]
 
@@ -1928,6 +1969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,10 +2116,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.16",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2079,7 +2144,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -2167,6 +2245,20 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "typenum"
@@ -2372,6 +2464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2631,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]

--- a/crates/rs-macro/Cargo.toml
+++ b/crates/rs-macro/Cargo.toml
@@ -18,4 +18,6 @@ quote = "1.0"
 syn = "2.0.15"
 serde_json = "1.0.74"
 thiserror.workspace = true
-cainome-cairo-serde.workspace = true
+
+[dev-dependencies]
+trybuild = "1.0.99"

--- a/crates/rs-macro/Cargo.toml
+++ b/crates/rs-macro/Cargo.toml
@@ -9,9 +9,11 @@ proc-macro = true
 [dependencies]
 anyhow.workspace = true         
 starknet.workspace = true
+cainome-cairo-serde.workspace = true
 cainome-parser.workspace = true
 cainome-rs.workspace = true
 proc-macro2 = "1.0"
+proc-macro-error = "1.0.4"
 quote = "1.0"
 syn = "2.0.15"
 serde_json = "1.0.74"

--- a/crates/rs-macro/src/lib.rs
+++ b/crates/rs-macro/src/lib.rs
@@ -1,6 +1,7 @@
 use cainome_parser::{AbiParser, AbiParserLegacy};
 use cainome_rs::{self};
 use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
 use quote::quote;
 
 mod macro_inputs;
@@ -10,11 +11,13 @@ mod spanned;
 use crate::macro_inputs::ContractAbi;
 use crate::macro_inputs_legacy::ContractAbiLegacy;
 
+#[proc_macro_error]
 #[proc_macro]
 pub fn abigen(input: TokenStream) -> TokenStream {
     abigen_internal(input)
 }
 
+#[proc_macro_error]
 #[proc_macro]
 pub fn abigen_legacy(input: TokenStream) -> TokenStream {
     abigen_internal_legacy(input)

--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -11,6 +11,7 @@
 //!
 //! TODO: support the full artifact JSON to be able to
 //! deploy contracts from abigen.
+use proc_macro_error::emit_error;
 use quote::ToTokens;
 use starknet::core::types::contract::{AbiEntry, SierraClass};
 use std::collections::{HashMap, HashSet};
@@ -114,10 +115,16 @@ impl Parse for ContractAbi {
 
                     for type_alias in parsed {
                         if !abi_types.insert(type_alias.abi.clone()) {
-                            panic!("{} duplicate abi type", type_alias.abi)
+                            emit_error!(
+                                type_alias.span(),
+                                format!("{} duplicate abi type", type_alias.abi)
+                            );
                         }
                         if !aliases.insert(type_alias.alias.clone()) {
-                            panic!("{} duplicate alias name", type_alias.alias)
+                            emit_error!(
+                                type_alias.span(),
+                                format!("{} duplicate alias name", type_alias.alias)
+                            );
                         }
 
                         let ta = type_alias.into_inner();
@@ -146,7 +153,7 @@ impl Parse for ContractAbi {
                         derives.push(derive.to_token_stream().to_string());
                     }
                 }
-                _ => panic!("unexpected named parameter `{}`", name),
+                _ => emit_error!(name.span(), format!("unexpected named parameter `{name}`")),
             }
         }
 

--- a/crates/rs-macro/src/macro_inputs_legacy.rs
+++ b/crates/rs-macro/src/macro_inputs_legacy.rs
@@ -11,6 +11,7 @@
 //!
 //! TODO: support the full artifact JSON to be able to
 //! deploy contracts from abigen.
+use proc_macro_error::emit_error;
 use quote::ToTokens;
 use starknet::core::types::contract::legacy::{LegacyContractClass, RawLegacyAbiEntry};
 use std::collections::{HashMap, HashSet};
@@ -109,10 +110,16 @@ impl Parse for ContractAbiLegacy {
 
                     for type_alias in parsed {
                         if !abi_types.insert(type_alias.abi.clone()) {
-                            panic!("{} duplicate abi type", type_alias.abi)
+                            emit_error!(
+                                type_alias.span(),
+                                format!("{} duplicate abi type", type_alias.abi)
+                            );
                         }
                         if !aliases.insert(type_alias.alias.clone()) {
-                            panic!("{} duplicate alias name", type_alias.alias)
+                            emit_error!(
+                                type_alias.span(),
+                                format!("{} duplicate alias name", type_alias.alias)
+                            );
                         }
 
                         let ta = type_alias.into_inner();
@@ -124,7 +131,7 @@ impl Parse for ContractAbiLegacy {
                     parenthesized!(content in input);
                     output_path = Some(content.parse::<LitStr>()?.value());
                 }
-                _ => panic!("unexpected named parameter `{}`", name),
+                _ => emit_error!(name.span(), format!("unexpected named parameter `{name}`")),
             }
         }
 

--- a/crates/rs-macro/tests/abigen/duplicate_abi_type.rs
+++ b/crates/rs-macro/tests/abigen/duplicate_abi_type.rs
@@ -1,0 +1,26 @@
+#![no_main]
+use cainome_rs_macro::abigen;
+
+abigen!(
+    MyContract,
+    r#"[
+        {
+            "type": "struct",
+            "name": "core::integer::u256",
+            "members": [
+              {
+                "name": "low",
+                "type": "core::integer::u128"
+              },
+              {
+                "name": "high",
+                "type": "core::integer::u128"
+              }
+            ]
+        }
+    ]"#,
+    type_aliases {
+        core::integer::u256 as MyStruct1;
+        core::integer::u256 as MyStruct2;
+    }
+);

--- a/crates/rs-macro/tests/abigen/duplicate_abi_type.stderr
+++ b/crates/rs-macro/tests/abigen/duplicate_abi_type.stderr
@@ -1,0 +1,5 @@
+error: core::integer::u256 duplicate abi type
+  --> tests/abigen/duplicate_abi_type.rs:24:9
+   |
+24 |         core::integer::u256 as MyStruct2;
+   |         ^^^^

--- a/crates/rs-macro/tests/abigen/duplicate_alias_name.rs
+++ b/crates/rs-macro/tests/abigen/duplicate_alias_name.rs
@@ -1,0 +1,36 @@
+#![no_main]
+use cainome_rs_macro::abigen;
+
+abigen!(
+    MyStruct,
+    r#"[
+        {
+            "type": "struct",
+            "name": "core::integer::u256",
+            "members": [
+              {
+                "name": "low",
+                "type": "core::integer::u128"
+              },
+              {
+                "name": "high",
+                "type": "core::integer::u128"
+              }
+            ]
+        },
+        {
+            "type": "struct",
+            "name": "core::starknet::eth_address::EthAddress",
+            "members": [
+              {
+                "name": "address",
+                "type": "core::felt252"
+              }
+            ]
+        }
+    ]"#,
+    type_aliases {
+        core::integer::u256 as MyStruct;
+        core::starknet::eth_address::EthAddress as MyStruct;
+    }
+);

--- a/crates/rs-macro/tests/abigen/duplicate_alias_name.stderr
+++ b/crates/rs-macro/tests/abigen/duplicate_alias_name.stderr
@@ -1,0 +1,5 @@
+error: MyStruct duplicate alias name
+  --> tests/abigen/duplicate_alias_name.rs:34:9
+   |
+34 |         core::starknet::eth_address::EthAddress as MyStruct;
+   |         ^^^^

--- a/crates/rs-macro/tests/abigen/unexpected_named_parameter.rs
+++ b/crates/rs-macro/tests/abigen/unexpected_named_parameter.rs
@@ -1,0 +1,23 @@
+#![no_main]
+use cainome_rs_macro::abigen;
+
+abigen!(
+    MyStruct,
+    r#"[
+        {
+            "type": "struct",
+            "name": "core::integer::u256",
+            "members": [
+              {
+                "name": "low",
+                "type": "core::integer::u128"
+              },
+              {
+                "name": "high",
+                "type": "core::integer::u128"
+              }
+            ]
+        }
+    ]"#,
+    my_other_parameter(path = "hello")
+);

--- a/crates/rs-macro/tests/abigen/unexpected_named_parameter.stderr
+++ b/crates/rs-macro/tests/abigen/unexpected_named_parameter.stderr
@@ -1,0 +1,5 @@
+error: unexpected named parameter `my_other_parameter`
+  --> tests/abigen/unexpected_named_parameter.rs:22:5
+   |
+22 |     my_other_parameter(path = "hello")
+   |     ^^^^^^^^^^^^^^^^^^

--- a/crates/rs-macro/tests/tests.rs
+++ b/crates/rs-macro/tests/tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_compile_fail_abigen() {
+    let cases = trybuild::TestCases::new();
+    cases.compile_fail("tests/abigen/*.rs");
+}


### PR DESCRIPTION
- Adds proc-macro-error to replace some panics for the `abigen` and `abigen_legacy` macros
- Adds `trybuild` for some failing paths testing of the `abigen!`.