### PR TITLE
update package version in Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cainome"
-version = "0.2.3"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cainome"
-version = "0.2.3"
+version = "0.4.3"
 edition = "2021"
 
 [workspace]


### PR DESCRIPTION
Package version in Cargo.toml was still 0.2.3 which is quite confusing in build output:
```console
  Compiling cainome v0.2.3 (https://github.com/cartridge-gg/cainome?tag=v0.4.0#0d29bb06)
```