### PR TITLE
feat(macro): support embedding abi as literal json

### DIFF
--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -4,10 +4,13 @@
 //! passed to the macro. We should then parse the
 //! token stream to ensure the arguments are correct.
 //!
-//! At this moment, the macro supports one fashion:
+//! The macro supports two forms:
 //!
-//! Loading from a file with only the ABI array.
-//! abigen!(ContractName, "path/to/abi.json"
+//! 1. Loading from a file with the ABI array:
+//! abigen!(ContractName, "path/to/abi.json")
+//!
+//! 2. Direct JSON array input:
+//! abigen!(ContractName, [{"type": "function", ...}])
 //!
 //! TODO: support the full artifact JSON to be able to
 //! deploy contracts from abigen.
@@ -16,8 +19,10 @@ use quote::ToTokens;
 use starknet::core::types::contract::{AbiEntry, SierraClass};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::io::BufReader;
 use std::path::Path;
 use std::str::FromStr;
+use syn::parse::ParseBuffer;
 use syn::{
     braced,
     ext::IdentExt,
@@ -49,42 +54,53 @@ impl Parse for ContractAbi {
 
         // ABI path or content.
 
-        // Path rooted to the Cargo.toml location if it's a file.
-        let abi_or_path = input.parse::<LitStr>()?;
+        // Parse either a JSON array literal or a path to the contract class artifact.
+        //
+        // If the input starts with a `[` token then we parse it as a JSON array.
+        let abi = if input.peek(syn::token::Bracket) {
+            let array_content = input.parse::<proc_macro2::TokenStream>()?;
+            let array_str = dbg!(array_content.to_string());
 
-        #[allow(clippy::collapsible_else_if)]
-        let abi = if abi_or_path.value().ends_with(".json") {
-            let json_path = if abi_or_path.value().starts_with(CARGO_MANIFEST_DIR) {
-                let manifest_dir = env!("CARGO_MANIFEST_DIR");
-                let new_dir = Path::new(manifest_dir)
-                    .join(abi_or_path.value().trim_start_matches(CARGO_MANIFEST_DIR))
-                    .to_string_lossy()
-                    .to_string();
+            serde_json::from_str::<Vec<AbiEntry>>(&array_str)
+                .map_err(|e| syn::Error::new(input.span(), format!("Invalid ABI format: {e}")))?
+        }
+        // Otherwise, parse it either as a path to the full JSON contract class artifact
+        else {
+            // Handle file path case
+            let abi_str_or_path = input.parse::<LitStr>()?;
 
-                LitStr::new(&new_dir, proc_macro2::Span::call_site())
-            } else {
-                abi_or_path
-            };
+            if abi_str_or_path.value().ends_with(".json") {
+                let json_path = if abi_str_or_path.value().starts_with(CARGO_MANIFEST_DIR) {
+                    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+                    let new_dir = Path::new(manifest_dir)
+                        .join(
+                            abi_str_or_path
+                                .value()
+                                .trim_start_matches(CARGO_MANIFEST_DIR),
+                        )
+                        .to_string_lossy()
+                        .to_string();
 
-            // To prepare the declare and deploy features, we also
-            // accept a full Sierra artifact for the ABI.
-            // To support declare and deploy, the full class must be stored.
-            if let Ok(sierra) =
-                serde_json::from_reader::<_, SierraClass>(open_json_file(&json_path.value())?)
-            {
-                sierra.abi
+                    LitStr::new(&new_dir, proc_macro2::Span::call_site())
+                } else {
+                    abi_str_or_path
+                };
+
+                // To prepare the declare and deploy features, we also
+                // accept a full Sierra artifact for the ABI.
+                // To support declare and deploy, the full class must be stored.
+                let file = open_json_file(&json_path.value())?;
+                if let Ok(class) = serde_json::from_reader::<_, SierraClass>(BufReader::new(&file))
+                {
+                    class.abi
+                } else {
+                    serde_json::from_reader::<_, Vec<AbiEntry>>(BufReader::new(&file)).map_err(
+                        |e| syn::Error::new(json_path.span(), format!("JSON parse error: {e}")),
+                    )?
+                }
             } else {
-                serde_json::from_reader::<_, Vec<AbiEntry>>(open_json_file(&json_path.value())?)
-                    .map_err(|e| {
-                        syn::Error::new(json_path.span(), format!("JSON parse error: {}", e))
-                    })?
-            }
-        } else {
-            if let Ok(sierra) = serde_json::from_str::<SierraClass>(&abi_or_path.value()) {
-                sierra.abi
-            } else {
-                serde_json::from_str::<Vec<AbiEntry>>(&abi_or_path.value()).map_err(|e| {
-                    syn::Error::new(abi_or_path.span(), format!("JSON parse error: {}", e))
+                serde_json::from_str::<Vec<AbiEntry>>(&abi_str_or_path.value()).map_err(|e| {
+                    syn::Error::new(abi_str_or_path.span(), format!("JSON parse error: {}", e))
                 })?
             }
         };

--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -59,7 +59,7 @@ impl Parse for ContractAbi {
         // If the input starts with a `[` token then we parse it as a JSON array.
         let abi = if input.peek(syn::token::Bracket) {
             let array_content = input.parse::<proc_macro2::TokenStream>()?;
-            let array_str = dbg!(array_content.to_string());
+            let array_str = array_content.to_string();
 
             serde_json::from_str::<Vec<AbiEntry>>(&array_str)
                 .map_err(|e| syn::Error::new(input.span(), format!("Invalid ABI format: {e}")))?

--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -22,7 +22,6 @@ use std::fs::File;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::path::Path;
 use std::str::FromStr;
-use syn::parse::ParseBuffer;
 use syn::{
     braced,
     ext::IdentExt,

--- a/examples/json_abi.rs
+++ b/examples/json_abi.rs
@@ -7,6 +7,14 @@ use url::Url;
 
 abigen!(MyContractFile, "./contracts/abi/simple_types.abi.json",);
 
+abigen!(
+    MyContractLitStr,
+    "[{\"type\":\"function\",\"name\":\"get_bool\",\
+	\"inputs\":[],\"outputs\":[{\"type\":\"core::bool\"}],\"state_mutability\":\
+	\"view\"},{\"type\":\"function\",\"name\":\"get_felt\",\"inputs\":[],\"outputs\":\
+	[{\"type\":\"core::felt252\"}],\"state_mutability\":\"view\"}]",
+);
+
 abigen!(MyContractEmbed, [
     {
     "type": "function",
@@ -54,6 +62,10 @@ async fn main() {
     let _ = contract.get_felt().call().await.unwrap();
 
     let contract = MyContractFileReader::new(felt!("0x1337"), &provider);
+    let _ = contract.get_bool().call().await.unwrap();
+    let _ = contract.get_felt().call().await.unwrap();
+
+    let contract = MyContractLitStrReader::new(felt!("0x1337"), &provider);
     let _ = contract.get_bool().call().await.unwrap();
     let _ = contract.get_felt().call().await.unwrap();
 }

--- a/examples/json_abi.rs
+++ b/examples/json_abi.rs
@@ -1,0 +1,59 @@
+use cainome::rs::abigen;
+use starknet::{
+    macros::felt,
+    providers::{jsonrpc::HttpTransport, JsonRpcClient},
+};
+use url::Url;
+
+abigen!(MyContractFile, "./contracts/abi/simple_types.abi.json",);
+
+abigen!(MyContractEmbed, [
+    {
+    "type": "function",
+    "name": "get_bool",
+    "inputs": [],
+    "outputs": [
+      {
+        "type": "core::bool"
+      }
+    ],
+    "state_mutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "set_bool",
+    "inputs": [
+      {
+        "name": "v",
+        "type": "core::bool"
+      }
+    ],
+    "outputs": [],
+    "state_mutability": "external"
+  },
+  {
+    "type": "function",
+    "name": "get_felt",
+    "inputs": [],
+    "outputs": [
+      {
+        "type": "core::felt252"
+      }
+    ],
+    "state_mutability": "view"
+  }
+]);
+
+#[tokio::main]
+async fn main() {
+    let url = Url::parse("http://localhost:5050").unwrap();
+    let provider = JsonRpcClient::new(HttpTransport::new(url));
+
+    let contract = MyContractEmbedReader::new(felt!("0x1337"), &provider);
+    let _ = contract.get_bool().call().await.unwrap();
+    let _ = contract.get_felt().call().await.unwrap();
+
+    let contract = MyContractFileReader::new(felt!("0x1337"), &provider);
+    let _ = contract.get_bool().call().await.unwrap();
+    let _ = contract.get_felt().call().await.unwrap();
+}


### PR DESCRIPTION
Allow embedding the ABI JSON array directly into the macro call as one of the way of passing the ABI. There's no breaking changes because the old behaviours are still preserved.

Usage example:

```rust
abigen!(MyContract, [
  {
  "type": "function",
  "name": "foo",
  "inputs": [],
  "outputs": [
    {
      "type": "core::bool"
    }
  ],
  "state_mutability": "view"
}]);


```