### PR TITLE
chore: change ci actions-rs to dtolnay, version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Compile contracts
         uses: software-mansion/setup-scarb@v1
@@ -26,14 +26,12 @@ jobs:
           cd ./contracts && make generate_artifacts
 
       - name: Setup toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-          override: true
 
       - name: Run cargo tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 20
           max_attempts: 3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: "Setup stable toolchain"
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Use Rust cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Check against Cargo.toml"
         run: |
@@ -85,14 +85,10 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Setup stable toolchain"
-        uses: "actions-rs/toolchain@v1"
-        with:
-          toolchain: "stable"
-          profile: "minimal"
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: "Build crate"
         run: |
@@ -110,7 +106,7 @@ jobs:
 
   #   steps:
   #     - name: "Checkout source code"
-  #       uses: "actions/checkout@v3"
+  #       uses: "actions/checkout@v4"
 
   #     - name: "Login to crates.io"
   #       run: |


### PR DESCRIPTION
https://github.com/actions-rs/toolchain is deprecated so I'm updating to widespead alternative