### PR TITLE
Attempt to solve issue with Duplicating composite instance names imported from different namespaces

### DIFF
--- a/crates/parser/src/tokens/composite.rs
+++ b/crates/parser/src/tokens/composite.rs
@@ -96,6 +96,7 @@ pub struct Composite {
     pub r#type: CompositeType,
     pub is_event: bool,
     pub alias: Option<String>,
+    pub depth: usize,
 }
 
 impl Composite {
@@ -120,6 +121,7 @@ impl Composite {
     /// Returns an error otherwise.
     pub fn parse(type_path: &str) -> CainomeResult<Self> {
         let type_path = escape_rust_keywords(type_path);
+
         let generic_args = genericity::extract_generics_args(&type_path)?;
 
         Ok(Self {
@@ -163,7 +165,7 @@ impl Composite {
 
     pub fn type_name(&self) -> String {
         // TODO: need to opti that with regex?
-        extract_type_path_with_depth(&self.type_path_no_generic(), 0)
+        extract_type_path_with_depth(&self.type_path_no_generic(), self.depth)
     }
 
     pub fn type_name_or_alias(&self) -> String {
@@ -304,6 +306,7 @@ mod tests {
             r#type: CompositeType::Unknown,
             is_event: false,
             alias: None,
+            depth: 0,
         };
 
         assert_eq!(Composite::parse("module::MyStruct").unwrap(), expected);
@@ -319,6 +322,7 @@ mod tests {
             r#type: CompositeType::Unknown,
             is_event: false,
             alias: None,
+            depth: 0,
         };
 
         assert_eq!(
@@ -340,6 +344,7 @@ mod tests {
             r#type: CompositeType::Unknown,
             is_event: false,
             alias: None,
+            depth: 0,
         };
 
         assert_eq!(
@@ -358,6 +363,7 @@ mod tests {
             r#type: CompositeType::Unknown,
             is_event: false,
             alias: None,
+            depth: 0,
         };
         assert_eq!(c.type_name(), "MyStruct");
 

--- a/crates/parser/src/tokens/mod.rs
+++ b/crates/parser/src/tokens/mod.rs
@@ -100,6 +100,13 @@ impl Token {
         }
     }
 
+    pub fn deepen(&mut self, depth: usize) {
+        match self {
+            Token::Composite(t) => t.depth += depth,
+            _ => (),
+        }
+    }
+
     // TODO: we may remove these two functions...! And change types somewhere..
     pub fn to_composite(&self) -> CainomeResult<&Composite> {
         match self {
@@ -262,6 +269,7 @@ impl Token {
                     r#type: comp.r#type,
                     is_event: comp.is_event,
                     alias: comp.alias,
+                    depth: 0,
                 })
             }
             Token::Function(func) => Token::Function(Function {


### PR DESCRIPTION
I'm checking if name collision exist and register a type alias (if there is none already)

Issue https://github.com/cartridge-gg/cainome/issues/90