### PR TITLE
feat: support jsonrpc 0.9.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,9 +1897,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "starknet"
-version = "0.16.0"
+version = "0.17.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e0e01a3e521a53138b774591bacb63032cfb1c4c98c93d5ce4dda96457222b"
+checksum = "b9c9e90938ff10648a2ef87d1fee28fccdcc428f6ded1f9b64657ccfbbfeff64"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.15.0"
+version = "0.16.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7961299fe73e642f1c2c6b8297cc5702740b000ce2b3956c1ab349f53654107e"
+checksum = "27b0a53f50fff55946699637e930eb764bb18ddabd392cbe4fd7271b2b223b40"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1928,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.15.0"
+version = "0.16.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e91bb0ec9b25b8cd0579540f66fb3eb965b43fbf65789a4bda65073aa43662"
+checksum = "25948c499faf8de208ff6a64be5a87be8bb58cb30138dc578311ea7071190af8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.15.0"
+version = "0.16.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebd248c1503f89d74f98bfb38119f6421ffb81b23f3404f33b268539d0c4cb6"
+checksum = "f6266bffbcf0ccfde812f9497dc847e2ea269bd4316e5373ec562165ceba014f"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
@@ -2005,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.4"
+version = "0.2.5-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebbaa813de0006d0ef21c00ed4395fa06ea4fec3ef0bdaad212aded2a1dd11f"
+checksum = "ed7b5b575473d4734c3b736735a2099cc14f66be26c6f9895c1a345f436012ed"
 dependencies = [
  "starknet-core",
  "syn 2.0.101",
@@ -2015,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.15.0"
+version = "0.16.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11aa3094e646d6fe49d2cfdc49b99b42b280b170518eeb50f759d62cccbf4ae"
+checksum = "dfab31dd85ecaef7d9d15e1c3bbefc06c7f0fe6fbe56a8bc2b26c9c1ba7d42f9"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.13.0"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e60350b8a56451cd937bdea01bee50519a38611f277c06bc2bdc7eaf103a6a"
+checksum = "dd907b1e3da29d9215f8a41e980f5965c4bb28eb43ca55902d37ee2ccc032575"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2.5"
-starknet = "0.16"
+# temp: change this to proper crates.io version
+starknet = "0.17.0-rc.2"
 starknet-types-core = "0.1"
 
 [dependencies]

--- a/crates/cairo-serde/src/call.rs
+++ b/crates/cairo-serde/src/call.rs
@@ -20,7 +20,7 @@ where
     pub fn new(call_raw: FunctionCall, provider: &'p P) -> Self {
         Self {
             call_raw,
-            block_id: BlockId::Tag(BlockTag::Pending),
+            block_id: BlockId::Tag(BlockTag::PreConfirmed),
             provider,
             rust_type: PhantomData,
         }

--- a/crates/rs-macro/README.md
+++ b/crates/rs-macro/README.md
@@ -116,7 +116,7 @@ The expansion of the macros generates the following:
   let contract_reader = MyContractReader::new(contract_address, &provider);
   ```
 - For each **view**, the contract type and the contract reader type contain a function with the exact same arguments. Calling the function returns a `cainome_cairo_serde::call::FCall` struct to allow you to customize how you want the function to be called. Currently, the only setting is the `block_id`. Finally, to actually do the RPC call, you have to use `call()` method on the `FCall` struct.
-  The default `block_id` value is `BlockTag::Pending`.
+  The default `block_id` value is `BlockTag::PreConfirmed`.
   ```rust
   let my_struct = contract
       .get_my_struct()

--- a/crates/rs/src/expand/contract.rs
+++ b/crates/rs/src/expand/contract.rs
@@ -31,7 +31,7 @@ impl CairoContract {
 
             impl<A: #snrs_accounts::ConnectedAccount + Sync> #contract_name<A> {
                 pub fn new(address: #snrs_types::Felt, account: A) -> Self {
-                    Self { address, account, block_id: #snrs_types::BlockId::Tag(#snrs_types::BlockTag::Pending) }
+                    Self { address, account, block_id: #snrs_types::BlockId::Tag(#snrs_types::BlockTag::PreConfirmed) }
                 }
 
                 pub fn set_contract_address(&mut self, address: #snrs_types::Felt) {
@@ -63,7 +63,7 @@ impl CairoContract {
                     address: #snrs_types::Felt,
                     provider: P,
                 ) -> Self {
-                    Self { address, provider, block_id: #snrs_types::BlockId::Tag(#snrs_types::BlockTag::Pending) }
+                    Self { address, provider, block_id: #snrs_types::BlockId::Tag(#snrs_types::BlockTag::PreConfirmed) }
                 }
 
                 pub fn set_contract_address(&mut self, address: #snrs_types::Felt) {

--- a/examples/alias_skip.rs
+++ b/examples/alias_skip.rs
@@ -62,7 +62,7 @@ async fn main() {
 
     let contract_address = declare_deploy_contract(&katana).await;
     let mut account = katana.account(1);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
+    account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
 
     let contract = MyContract::new(contract_address, account);
 
@@ -77,7 +77,7 @@ async fn main() {
 /*
 async fn declare_deploy_contract(katana: &KatanaRunner) -> Felt {
     let mut account = katana.account(1);
-    account.set_block_id(BlockId::Tag(BlockTag::Pending));
+    account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
 
     let contract_artifact: SierraClass = serde_json::from_reader(
         std::fs::File::open("./contracts/target/dev/contracts_structs.contract_class.json")


### PR DESCRIPTION
Bumps the supported Starknet JSON-RPC spec to [0.9.0-rc.2](https://github.com/starkware-libs/starknet-specs/blob/v0.9.0-rc.2/api/starknet_api_openrpc.json). 

~~`starknet-rs` still hasn't published a version on `crates.io` yet so for now we're using the exact git rev.~~ New version published ([`0.17.0-rc.2`](https://crates.io/crates/starknet/0.17.0-rc.2)) with new rpc support.

Currently, this bump is primarily made in order to compile Katana with the new RPC spec as it relies on `starknet-rs` too.
