### PR TITLE
feat(cairo-serde): lossy utf8 & bytes for `ByteArray`

### DIFF
--- a/crates/cairo-serde/src/types/byte_array.rs
+++ b/crates/cairo-serde/src/types/byte_array.rs
@@ -578,7 +578,6 @@ mod tests {
 
     #[test]
     fn test_to_string_lossy_valid_utf8() {
-        // Test that to_string_lossy works correctly with valid UTF-8
         let b = ByteArray {
             data: vec![],
             pending_word: Felt::from_hex(
@@ -588,13 +587,11 @@ mod tests {
             pending_word_len: 4,
         };
 
-        // Should return "ABCD" without errors
         assert_eq!(b.to_string_lossy(), "ABCD");
     }
 
     #[test]
     fn test_to_string_lossy_invalid_utf8() {
-        // Test that to_string_lossy handles invalid UTF-8 gracefully
         let b = ByteArray {
             data: vec![],
             pending_word: Felt::from_hex(
@@ -604,31 +601,25 @@ mod tests {
             pending_word_len: 4,
         };
 
-        // Should NOT panic and return a lossy string with replacement characters
         let result = b.to_string_lossy();
-        // Invalid UTF-8 bytes should be replaced with the replacement character U+FFFD
         assert!(result.contains('\u{FFFD}'));
-        // Should complete without panicking
         assert!(!result.is_empty());
     }
 
     #[test]
     fn test_to_string_lossy_empty() {
-        // Test that to_string_lossy works with empty ByteArray
         let b = ByteArray::default();
         assert_eq!(b.to_string_lossy(), "");
     }
 
     #[test]
     fn test_to_string_lossy_with_emojis() {
-        // Test that to_string_lossy works correctly with multi-byte UTF-8 characters
         let b: ByteArray = "🦀🌟".try_into().unwrap();
         assert_eq!(b.to_string_lossy(), "🦀🌟");
     }
 
     #[test]
     fn test_to_string_lossy_data_and_pending() {
-        // Test with both data and pending word
         let b = ByteArray {
             data: vec![Felt::from_hex(
                 "0x004142434445464748494a4b4c4d4e4f505152535455565758595a3132333435",

--- a/crates/cairo-serde/src/types/byte_array.rs
+++ b/crates/cairo-serde/src/types/byte_array.rs
@@ -196,7 +196,10 @@ impl ByteArray {
         }
 
         if self.pending_word_len > 0 {
-            s.push_str(&felt_to_utf8_lossy(&self.pending_word, self.pending_word_len));
+            s.push_str(&felt_to_utf8_lossy(
+                &self.pending_word,
+                self.pending_word_len,
+            ));
         }
 
         s
@@ -552,18 +555,15 @@ mod tests {
         let original_string = "Hello, World! 🦀";
         let byte_array = ByteArray::from_string(original_string).unwrap();
         let bytes = byte_array.to_bytes();
-        
+
         assert_eq!(bytes, original_string.as_bytes());
         assert_eq!(String::from_utf8(bytes).unwrap(), original_string);
     }
 
     #[test]
     fn test_to_bytes_with_data_and_pending() {
-        let b = ByteArray::from_string(
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345ABCD",
-        )
-        .unwrap();
-        
+        let b = ByteArray::from_string("ABCDEFGHIJKLMNOPQRSTUVWXYZ12345ABCD").unwrap();
+
         let bytes = b.to_bytes();
         assert_eq!(bytes, b"ABCDEFGHIJKLMNOPQRSTUVWXYZ12345ABCD");
     }
@@ -572,7 +572,7 @@ mod tests {
     fn test_to_bytes_empty() {
         let b = ByteArray::default();
         let bytes = b.to_bytes();
-        
+
         assert_eq!(bytes, Vec::<u8>::new());
     }
 }

--- a/crates/cairo-serde/src/types/byte_array.rs
+++ b/crates/cairo-serde/src/types/byte_array.rs
@@ -184,6 +184,41 @@ impl ByteArray {
 
         Ok(s)
     }
+
+    /// Converts `ByteArray` instance into a UTF-8 encoded string on success.
+    /// Returns error if the `ByteArray` contains an invalid UTF-8 string.
+    pub fn to_string_lossy(&self) -> String {
+        let mut s = String::new();
+
+        for d in &self.data {
+            // Chunks are always 31 bytes long (MAX_WORD_LEN).
+            s.push_str(&felt_to_utf8_lossy(&d.felt(), MAX_WORD_LEN));
+        }
+
+        if self.pending_word_len > 0 {
+            s.push_str(&felt_to_utf8_lossy(&self.pending_word, self.pending_word_len));
+        }
+
+        s
+    }
+
+    /// Converts `ByteArray` instance into raw bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        for d in &self.data {
+            // Chunks are always 31 bytes long (MAX_WORD_LEN).
+            let felt_bytes = d.felt().to_bytes_be();
+            bytes.extend_from_slice(&felt_bytes[1..1 + MAX_WORD_LEN]);
+        }
+
+        if self.pending_word_len > 0 {
+            let felt_bytes = self.pending_word.to_bytes_be();
+            bytes.extend_from_slice(&felt_bytes[1 + MAX_WORD_LEN - self.pending_word_len..]);
+        }
+
+        bytes
+    }
 }
 
 /// Converts a felt into a UTF-8 string.
@@ -206,6 +241,28 @@ fn felt_to_utf8(felt: &Felt, len: usize) -> Result<String, FromUtf8Error> {
     }
 
     String::from_utf8(buffer)
+}
+
+/// Converts a felt into a UTF-8 string.
+/// Returns a lossy string if the felt contains an invalid UTF-8 string.
+///
+/// # Arguments
+///
+/// * `felt` - The `Felt` to convert. In the context of `ByteArray` this
+///   felt always contains at most 31 bytes.
+/// * `len` - The number of bytes in the felt, at most 31. In the context
+///   of `ByteArray`, we don't need to check `len` as the `MAX_WORD_LEN`
+///   already protect against that.
+fn felt_to_utf8_lossy(felt: &Felt, len: usize) -> String {
+    let mut buffer = Vec::new();
+
+    // ByteArray always enforce to have the first byte equal to 0.
+    // That's why we start to 1.
+    for byte in felt.to_bytes_be()[1 + MAX_WORD_LEN - len..].iter() {
+        buffer.push(*byte)
+    }
+
+    String::from_utf8_lossy(&buffer).to_string()
 }
 
 impl TryFrom<String> for ByteArray {
@@ -488,5 +545,34 @@ mod tests {
                 pending_word_len: 8,
             }
         );
+    }
+
+    #[test]
+    fn test_to_bytes_round_trip() {
+        let original_string = "Hello, World! 🦀";
+        let byte_array = ByteArray::from_string(original_string).unwrap();
+        let bytes = byte_array.to_bytes();
+        
+        assert_eq!(bytes, original_string.as_bytes());
+        assert_eq!(String::from_utf8(bytes).unwrap(), original_string);
+    }
+
+    #[test]
+    fn test_to_bytes_with_data_and_pending() {
+        let b = ByteArray::from_string(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345ABCD",
+        )
+        .unwrap();
+        
+        let bytes = b.to_bytes();
+        assert_eq!(bytes, b"ABCDEFGHIJKLMNOPQRSTUVWXYZ12345ABCD");
+    }
+
+    #[test]
+    fn test_to_bytes_empty() {
+        let b = ByteArray::default();
+        let bytes = b.to_bytes();
+        
+        assert_eq!(bytes, Vec::<u8>::new());
     }
 }

--- a/crates/cairo-serde/src/types/byte_array.rs
+++ b/crates/cairo-serde/src/types/byte_array.rs
@@ -185,8 +185,8 @@ impl ByteArray {
         Ok(s)
     }
 
-    /// Converts `ByteArray` instance into a UTF-8 encoded string on success.
-    /// Returns error if the `ByteArray` contains an invalid UTF-8 string.
+    /// Converts `ByteArray` instance into a UTF-8 encoded string if possible.
+    /// Returns a lossy string if the `ByteArray` contains an invalid UTF-8 string.
     pub fn to_string_lossy(&self) -> String {
         let mut s = String::new();
 
@@ -574,5 +574,75 @@ mod tests {
         let bytes = b.to_bytes();
 
         assert_eq!(bytes, Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_to_string_lossy_valid_utf8() {
+        // Test that to_string_lossy works correctly with valid UTF-8
+        let b = ByteArray {
+            data: vec![],
+            pending_word: Felt::from_hex(
+                "0x0000000000000000000000000000000000000000000000000000000041424344",
+            )
+            .unwrap(),
+            pending_word_len: 4,
+        };
+
+        // Should return "ABCD" without errors
+        assert_eq!(b.to_string_lossy(), "ABCD");
+    }
+
+    #[test]
+    fn test_to_string_lossy_invalid_utf8() {
+        // Test that to_string_lossy handles invalid UTF-8 gracefully
+        let b = ByteArray {
+            data: vec![],
+            pending_word: Felt::from_hex(
+                "0x00000000000000000000000000000000000000000000000000000000ffffffff",
+            )
+            .unwrap(),
+            pending_word_len: 4,
+        };
+
+        // Should NOT panic and return a lossy string with replacement characters
+        let result = b.to_string_lossy();
+        // Invalid UTF-8 bytes should be replaced with the replacement character U+FFFD
+        assert!(result.contains('\u{FFFD}'));
+        // Should complete without panicking
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn test_to_string_lossy_empty() {
+        // Test that to_string_lossy works with empty ByteArray
+        let b = ByteArray::default();
+        assert_eq!(b.to_string_lossy(), "");
+    }
+
+    #[test]
+    fn test_to_string_lossy_with_emojis() {
+        // Test that to_string_lossy works correctly with multi-byte UTF-8 characters
+        let b: ByteArray = "🦀🌟".try_into().unwrap();
+        assert_eq!(b.to_string_lossy(), "🦀🌟");
+    }
+
+    #[test]
+    fn test_to_string_lossy_data_and_pending() {
+        // Test with both data and pending word
+        let b = ByteArray {
+            data: vec![Felt::from_hex(
+                "0x004142434445464748494a4b4c4d4e4f505152535455565758595a3132333435",
+            )
+            .unwrap()
+            .try_into()
+            .unwrap()],
+            pending_word: Felt::from_hex(
+                "0x0000000000000000000000000000000000000000000000000000000041424344",
+            )
+            .unwrap(),
+            pending_word_len: 4,
+        };
+
+        assert_eq!(b.to_string_lossy(), "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345ABCD");
     }
 }

--- a/crates/cairo-test-artifacts/src/generated_tests.rs
+++ b/crates/cairo-test-artifacts/src/generated_tests.rs
@@ -1,30 +1,115 @@
 // Generated test file - do not edit manually
-use cainome_cairo_serde::CairoSerde;
-use starknet::core::types::Felt;
 use cainome::rs::abigen;
+use cainome_cairo_serde::CairoSerde;
 #[allow(unused_imports)]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use starknet::core::types::Felt;
 
-abigen!(TestSimpleEnumVariant1, r#"[{"name":"contracts::abicov::enums::SimpleEnum","type":"enum","variants":[{"name":"Variant1","type":"()"},{"name":"Variant2","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestResultErrU32, r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestOptionSomeFelt, r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestOptionNoneFelt, r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestBoolFalse, r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestBoolTrue, r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestMixedEnumVariant1, r#"[{"name":"contracts::abicov::enums::MixedEnum","type":"enum","variants":[{"name":"Variant1","type":"core::felt252"},{"name":"Variant2","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestStructWithStruct, r#"[{"members":[{"name":"felt","type":"core::felt252"},{"name":"uint256","type":"core::integer::u256"},{"name":"uint64","type":"core::integer::u64"},{"name":"address","type":"core::starknet::contract_address::ContractAddress"},{"name":"class_hash","type":"core::starknet::class_hash::ClassHash"},{"name":"eth_address","type":"core::starknet::eth_address::EthAddress"},{"name":"tuple","type":"(core::felt252, core::integer::u256)"},{"name":"span","type":"core::array::Span::<core::felt252>"}],"name":"contracts::abicov::structs::Simple","type":"struct"},{"members":[{"name":"simple","type":"contracts::abicov::structs::Simple"}],"name":"contracts::abicov::structs::StructWithStruct","type":"struct"}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
-abigen!(TestResultOkFelt, r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(
+    TestSimpleEnumVariant1,
+    r#"[{"name":"contracts::abicov::enums::SimpleEnum","type":"enum","variants":[{"name":"Variant1","type":"()"},{"name":"Variant2","type":"()"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestResultErrU32,
+    r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestOptionSomeFelt,
+    r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestOptionNoneFelt,
+    r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestBoolFalse,
+    r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestBoolTrue,
+    r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestMixedEnumVariant1,
+    r#"[{"name":"contracts::abicov::enums::MixedEnum","type":"enum","variants":[{"name":"Variant1","type":"core::felt252"},{"name":"Variant2","type":"()"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestStructWithStruct,
+    r#"[{"members":[{"name":"felt","type":"core::felt252"},{"name":"uint256","type":"core::integer::u256"},{"name":"uint64","type":"core::integer::u64"},{"name":"address","type":"core::starknet::contract_address::ContractAddress"},{"name":"class_hash","type":"core::starknet::class_hash::ClassHash"},{"name":"eth_address","type":"core::starknet::eth_address::EthAddress"},{"name":"tuple","type":"(core::felt252, core::integer::u256)"},{"name":"span","type":"core::array::Span::<core::felt252>"}],"name":"contracts::abicov::structs::Simple","type":"struct"},{"members":[{"name":"simple","type":"contracts::abicov::structs::Simple"}],"name":"contracts::abicov::structs::StructWithStruct","type":"struct"}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
+abigen!(
+    TestResultOkFelt,
+    r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#,
+    derives(
+        Debug,
+        Clone,
+        PartialEq,
+        serde::Serialize,
+        serde::Deserialize
+    )
+);
 
 #[test]
 fn test_array_felt() {
     let description = r#"Array of felt252 values"#;
 
-    let expected_serialized = [
-        "0x3",
-        "0x1",
-        "0x2",
-        "0x3",
-    ];
+    let expected_serialized = ["0x3", "0x1", "0x2", "0x3"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -36,7 +121,11 @@ fn test_array_felt() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = vec![Felt::from_hex("0x1").unwrap(), Felt::from_hex("0x2").unwrap(), Felt::from_hex("0x3").unwrap()];
+    let test_instance = vec![
+        Felt::from_hex("0x1").unwrap(),
+        Felt::from_hex("0x2").unwrap(),
+        Felt::from_hex("0x3").unwrap(),
+    ];
 
     // Test serialization
     let serialized = Vec::<Felt>::cairo_serialize(&test_instance);
@@ -44,22 +133,30 @@ fn test_array_felt() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = Vec::<Felt>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_simple_enum_variant1() {
     let description = r#"SimpleEnum with first variant"#;
 
-    let expected_serialized = [
-        "0x0",
-    ];
+    let expected_serialized = ["0x0"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -76,22 +173,25 @@ fn test_simple_enum_variant1() {
     // Using actual abigen!-generated enum type
     let test_instance = SimpleEnum::Variant1;
     let serialized = SimpleEnum::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Enum serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Enum serialization mismatch"
+    );
     // Verify deserialization works by checking it produces the same serialization
     let deserialize_ptr = 0;
     let deserialized = SimpleEnum::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     let reserialized = SimpleEnum::cairo_serialize(&deserialized);
-    assert_eq!(serialized, reserialized, "Enum roundtrip serialization failed");
+    assert_eq!(
+        serialized, reserialized,
+        "Enum roundtrip serialization failed"
+    );
 }
 
 #[test]
 fn test_result_err_u32() {
     let description = r#"Result with Err(u32)"#;
 
-    let expected_serialized = [
-        "0x1",
-        "0x1c8",
-    ];
+    let expected_serialized = ["0x1", "0x1c8"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -107,21 +207,24 @@ fn test_result_err_u32() {
     // Using built-in Result<Felt, u32> (equivalent to abigen!-generated type)
     let test_instance = Err::<Felt, u32>(456_u32);
     let serialized = Result::<Felt, u32>::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Result<Felt, u32> Err serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Result<Felt, u32> Err serialization mismatch"
+    );
     let deserialize_ptr = 0;
-    let deserialized = Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Result<Felt, u32> Err roundtrip failed");
+    let deserialized =
+        Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Result<Felt, u32> Err roundtrip failed"
+    );
 }
 
 #[test]
 fn test_byte_array() {
     let description = r#"ByteArray with string data"#;
 
-    let expected_serialized = [
-        "0x0",
-        "0x48656c6c6f2c20436169726f21",
-        "0xd",
-    ];
+    let expected_serialized = ["0x0", "0x48656c6c6f2c20436169726f21", "0xd"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -141,23 +244,31 @@ fn test_byte_array() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized = cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    let deserialized =
+        cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_option_some_felt() {
     let description = r#"Option with Some(felt252)"#;
 
-    let expected_serialized = [
-        "0x0",
-        "0x2a",
-    ];
+    let expected_serialized = ["0x0", "0x2a"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -173,19 +284,23 @@ fn test_option_some_felt() {
     // Using built-in Option<Felt> (equivalent to abigen!-generated type)
     let test_instance = Some(Felt::from_hex("0x2a").unwrap());
     let serialized = Option::<Felt>::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Option<Felt> Some serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Option<Felt> Some serialization mismatch"
+    );
     let deserialize_ptr = 0;
     let deserialized = Option::<Felt>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Option<Felt> Some roundtrip failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Option<Felt> Some roundtrip failed"
+    );
 }
 
 #[test]
 fn test_option_none_felt() {
     let description = r#"Option with None"#;
 
-    let expected_serialized = [
-        "0x1",
-    ];
+    let expected_serialized = ["0x1"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -201,19 +316,23 @@ fn test_option_none_felt() {
     // Using built-in Option<Felt> (equivalent to abigen!-generated type)
     let test_instance = None::<Felt>;
     let serialized = Option::<Felt>::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Option<Felt> None serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Option<Felt> None serialization mismatch"
+    );
     let deserialize_ptr = 0;
     let deserialized = Option::<Felt>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Option<Felt> None roundtrip failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Option<Felt> None roundtrip failed"
+    );
 }
 
 #[test]
 fn test_bool_false() {
     let description = r#"Boolean false value"#;
 
-    let expected_serialized = [
-        "0x0",
-    ];
+    let expected_serialized = ["0x0"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -229,7 +348,10 @@ fn test_bool_false() {
     // Using built-in bool (equivalent to abigen!-generated Bool)
     let test_instance = false;
     let serialized = bool::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Bool serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Bool serialization mismatch"
+    );
     let deserialize_ptr = 0;
     let deserialized = bool::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     assert_eq!(test_instance, deserialized, "Bool roundtrip failed");
@@ -239,9 +361,7 @@ fn test_bool_false() {
 fn test_u32() {
     let description = r#"Maximum u32 value"#;
 
-    let expected_serialized = [
-        "0xffffffff",
-    ];
+    let expected_serialized = ["0xffffffff"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -261,23 +381,30 @@ fn test_u32() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u32::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_tuple_felt_u32() {
     let description = r#"Tuple of felt252 and u32"#;
 
-    let expected_serialized = [
-        "0x7b",
-        "0x1c8",
-    ];
+    let expected_serialized = ["0x7b", "0x1c8"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -297,13 +424,23 @@ fn test_tuple_felt_u32() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = <(Felt, u32)>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
@@ -325,7 +462,10 @@ fn test_u256_large() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = cainome_cairo_serde::U256 { low: 0xffffffffffffffffffffffffffffffff_u128, high: 0x123456789abcdef123456789abcdef12_u128 };
+    let test_instance = cainome_cairo_serde::U256 {
+        low: 0xffffffffffffffffffffffffffffffff_u128,
+        high: 0x123456789abcdef123456789abcdef12_u128,
+    };
 
     // Test serialization
     let serialized = cainome_cairo_serde::U256::cairo_serialize(&test_instance);
@@ -333,22 +473,31 @@ fn test_u256_large() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized = cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    let deserialized =
+        cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_u64() {
     let description = r#"Maximum u64 value"#;
 
-    let expected_serialized = [
-        "0xffffffffffffffff",
-    ];
+    let expected_serialized = ["0xffffffffffffffff"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -368,22 +517,30 @@ fn test_u64() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u64::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_bool_true() {
     let description = r#"Boolean true value"#;
 
-    let expected_serialized = [
-        "0x1",
-    ];
+    let expected_serialized = ["0x1"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -399,7 +556,10 @@ fn test_bool_true() {
     // Using built-in bool (equivalent to abigen!-generated Bool)
     let test_instance = true;
     let serialized = bool::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Bool serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Bool serialization mismatch"
+    );
     let deserialize_ptr = 0;
     let deserialized = bool::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     assert_eq!(test_instance, deserialized, "Bool roundtrip failed");
@@ -409,10 +569,7 @@ fn test_bool_true() {
 fn test_mixed_enum_variant1() {
     let description = r#"MixedEnum with felt252 variant"#;
 
-    let expected_serialized = [
-        "0x0",
-        "0x789",
-    ];
+    let expected_serialized = ["0x0", "0x789"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -429,21 +586,25 @@ fn test_mixed_enum_variant1() {
     // Using actual abigen!-generated enum type with data
     let test_instance = MixedEnum::Variant1(Felt::from_hex("0x789").unwrap());
     let serialized = MixedEnum::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Enum serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Enum serialization mismatch"
+    );
     // Verify deserialization works by checking it produces the same serialization
     let deserialize_ptr = 0;
     let deserialized = MixedEnum::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     let reserialized = MixedEnum::cairo_serialize(&deserialized);
-    assert_eq!(serialized, reserialized, "Enum roundtrip serialization failed");
+    assert_eq!(
+        serialized, reserialized,
+        "Enum roundtrip serialization failed"
+    );
 }
 
 #[test]
 fn test_felt252() {
     let description = r#"Basic felt252 value"#;
 
-    let expected_serialized = [
-        "0x1234567890abcdef",
-    ];
+    let expected_serialized = ["0x1234567890abcdef"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -463,23 +624,30 @@ fn test_felt252() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = Felt::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_u256() {
     let description = r#"U256 struct with low and high fields"#;
 
-    let expected_serialized = [
-        "0x123456789abcdef123456789abcdef12",
-        "0x0",
-    ];
+    let expected_serialized = ["0x123456789abcdef123456789abcdef12", "0x0"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -491,7 +659,10 @@ fn test_u256() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = cainome_cairo_serde::U256 { low: 0x123456789abcdef123456789abcdef12_u128, high: 0_u128 };
+    let test_instance = cainome_cairo_serde::U256 {
+        low: 0x123456789abcdef123456789abcdef12_u128,
+        high: 0_u128,
+    };
 
     // Test serialization
     let serialized = cainome_cairo_serde::U256::cairo_serialize(&test_instance);
@@ -499,22 +670,31 @@ fn test_u256() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized = cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    let deserialized =
+        cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_u128() {
     let description = r#"Large u128 value"#;
 
-    let expected_serialized = [
-        "0x112210f47de98115",
-    ];
+    let expected_serialized = ["0x112210f47de98115"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -534,13 +714,23 @@ fn test_u128() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u128::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
@@ -581,7 +771,10 @@ fn test_struct_with_struct() {
     let test_instance = StructWithStruct::cairo_deserialize(&expected_felt_values, 0).unwrap();
     // Test serialization using abigen!-generated type (tests serialization)
     let serialized = StructWithStruct::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Struct round-trip serialization failed");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Struct round-trip serialization failed"
+    );
     // Verify we can deserialize again (double round-trip)
     let deserialized_again = StructWithStruct::cairo_deserialize(&serialized, 0).unwrap();
     let reserialized = StructWithStruct::cairo_serialize(&deserialized_again);
@@ -592,9 +785,7 @@ fn test_struct_with_struct() {
 fn test_u8() {
     let description = r#"Maximum u8 value"#;
 
-    let expected_serialized = [
-        "0xff",
-    ];
+    let expected_serialized = ["0xff"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -614,24 +805,30 @@ fn test_u8() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u8::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_byte_array_empty() {
     let description = r#"Empty ByteArray"#;
 
-    let expected_serialized = [
-        "0x0",
-        "0x0",
-        "0x0",
-    ];
+    let expected_serialized = ["0x0", "0x0", "0x0"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -651,23 +848,31 @@ fn test_byte_array_empty() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized = cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    let deserialized =
+        cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_result_ok_felt() {
     let description = r#"Result with Ok(felt252)"#;
 
-    let expected_serialized = [
-        "0x0",
-        "0x7b",
-    ];
+    let expected_serialized = ["0x0", "0x7b"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -683,19 +888,24 @@ fn test_result_ok_felt() {
     // Using built-in Result<Felt, u32> (equivalent to abigen!-generated type)
     let test_instance = Ok::<Felt, u32>(Felt::from_hex("0x7b").unwrap());
     let serialized = Result::<Felt, u32>::cairo_serialize(&test_instance);
-    assert_eq!(serialized, expected_felt_values, "Result<Felt, u32> Ok serialization mismatch");
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Result<Felt, u32> Ok serialization mismatch"
+    );
     let deserialize_ptr = 0;
-    let deserialized = Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Result<Felt, u32> Ok roundtrip failed");
+    let deserialized =
+        Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Result<Felt, u32> Ok roundtrip failed"
+    );
 }
 
 #[test]
 fn test_eth_address() {
     let description = r#"EthAddress value"#;
 
-    let expected_serialized = [
-        "0x1234567890abcdef1234567890abcdef12345678",
-    ];
+    let expected_serialized = ["0x1234567890abcdef1234567890abcdef12345678"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -707,7 +917,9 @@ fn test_eth_address() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = cainome_cairo_serde::EthAddress::from(Felt::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap());
+    let test_instance = cainome_cairo_serde::EthAddress::from(
+        Felt::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap(),
+    );
 
     // Test serialization
     let serialized = cainome_cairo_serde::EthAddress::cairo_serialize(&test_instance);
@@ -715,25 +927,31 @@ fn test_eth_address() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized = cainome_cairo_serde::EthAddress::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    let deserialized =
+        cainome_cairo_serde::EthAddress::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
 
 #[test]
 fn test_array_u32() {
     let description = r#"Array of u32 values"#;
 
-    let expected_serialized = [
-        "0x3",
-        "0x1",
-        "0x2",
-        "0x3",
-    ];
+    let expected_serialized = ["0x3", "0x1", "0x2", "0x3"];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -753,12 +971,21 @@ fn test_array_u32() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
-    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
+    assert_eq!(
+        serialized.len(),
+        expected_felt_values.len(),
+        "Serialized length mismatch"
+    );
+    assert_eq!(
+        serialized, expected_felt_values,
+        "Serialized values mismatch"
+    );
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = Vec::<u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
+    assert_eq!(
+        test_instance, deserialized,
+        "Roundtrip deserialization failed"
+    );
 }
-

--- a/crates/cairo-test-artifacts/src/generated_tests.rs
+++ b/crates/cairo-test-artifacts/src/generated_tests.rs
@@ -1,115 +1,30 @@
 // Generated test file - do not edit manually
-use cainome::rs::abigen;
 use cainome_cairo_serde::CairoSerde;
-#[allow(unused_imports)]
-use serde::{Deserialize, Serialize};
 use starknet::core::types::Felt;
+use cainome::rs::abigen;
+#[allow(unused_imports)]
+use serde::{Serialize, Deserialize};
 
-abigen!(
-    TestSimpleEnumVariant1,
-    r#"[{"name":"contracts::abicov::enums::SimpleEnum","type":"enum","variants":[{"name":"Variant1","type":"()"},{"name":"Variant2","type":"()"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestResultErrU32,
-    r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestOptionSomeFelt,
-    r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestOptionNoneFelt,
-    r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestBoolFalse,
-    r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestBoolTrue,
-    r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestMixedEnumVariant1,
-    r#"[{"name":"contracts::abicov::enums::MixedEnum","type":"enum","variants":[{"name":"Variant1","type":"core::felt252"},{"name":"Variant2","type":"()"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestStructWithStruct,
-    r#"[{"members":[{"name":"felt","type":"core::felt252"},{"name":"uint256","type":"core::integer::u256"},{"name":"uint64","type":"core::integer::u64"},{"name":"address","type":"core::starknet::contract_address::ContractAddress"},{"name":"class_hash","type":"core::starknet::class_hash::ClassHash"},{"name":"eth_address","type":"core::starknet::eth_address::EthAddress"},{"name":"tuple","type":"(core::felt252, core::integer::u256)"},{"name":"span","type":"core::array::Span::<core::felt252>"}],"name":"contracts::abicov::structs::Simple","type":"struct"},{"members":[{"name":"simple","type":"contracts::abicov::structs::Simple"}],"name":"contracts::abicov::structs::StructWithStruct","type":"struct"}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
-abigen!(
-    TestResultOkFelt,
-    r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#,
-    derives(
-        Debug,
-        Clone,
-        PartialEq,
-        serde::Serialize,
-        serde::Deserialize
-    )
-);
+abigen!(TestSimpleEnumVariant1, r#"[{"name":"contracts::abicov::enums::SimpleEnum","type":"enum","variants":[{"name":"Variant1","type":"()"},{"name":"Variant2","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestResultErrU32, r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestOptionSomeFelt, r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestOptionNoneFelt, r#"[{"name":"core::option::Option::<core::felt252>","type":"enum","variants":[{"name":"Some","type":"core::felt252"},{"name":"None","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestBoolFalse, r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestBoolTrue, r#"[{"name":"core::bool","type":"enum","variants":[{"name":"False","type":"()"},{"name":"True","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestMixedEnumVariant1, r#"[{"name":"contracts::abicov::enums::MixedEnum","type":"enum","variants":[{"name":"Variant1","type":"core::felt252"},{"name":"Variant2","type":"()"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestStructWithStruct, r#"[{"members":[{"name":"felt","type":"core::felt252"},{"name":"uint256","type":"core::integer::u256"},{"name":"uint64","type":"core::integer::u64"},{"name":"address","type":"core::starknet::contract_address::ContractAddress"},{"name":"class_hash","type":"core::starknet::class_hash::ClassHash"},{"name":"eth_address","type":"core::starknet::eth_address::EthAddress"},{"name":"tuple","type":"(core::felt252, core::integer::u256)"},{"name":"span","type":"core::array::Span::<core::felt252>"}],"name":"contracts::abicov::structs::Simple","type":"struct"},{"members":[{"name":"simple","type":"contracts::abicov::structs::Simple"}],"name":"contracts::abicov::structs::StructWithStruct","type":"struct"}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
+abigen!(TestResultOkFelt, r#"[{"name":"core::result::Result::<core::felt252, core::integer::u32>","type":"enum","variants":[{"name":"Ok","type":"core::felt252"},{"name":"Err","type":"core::integer::u32"}]}]"#, derives(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize));
 
 #[test]
 fn test_array_felt() {
     let description = r#"Array of felt252 values"#;
 
-    let expected_serialized = ["0x3", "0x1", "0x2", "0x3"];
+    let expected_serialized = [
+        "0x3",
+        "0x1",
+        "0x2",
+        "0x3",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -121,11 +36,7 @@ fn test_array_felt() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = vec![
-        Felt::from_hex("0x1").unwrap(),
-        Felt::from_hex("0x2").unwrap(),
-        Felt::from_hex("0x3").unwrap(),
-    ];
+    let test_instance = vec![Felt::from_hex("0x1").unwrap(), Felt::from_hex("0x2").unwrap(), Felt::from_hex("0x3").unwrap()];
 
     // Test serialization
     let serialized = Vec::<Felt>::cairo_serialize(&test_instance);
@@ -133,30 +44,22 @@ fn test_array_felt() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = Vec::<Felt>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_simple_enum_variant1() {
     let description = r#"SimpleEnum with first variant"#;
 
-    let expected_serialized = ["0x0"];
+    let expected_serialized = [
+        "0x0",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -173,25 +76,22 @@ fn test_simple_enum_variant1() {
     // Using actual abigen!-generated enum type
     let test_instance = SimpleEnum::Variant1;
     let serialized = SimpleEnum::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Enum serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Enum serialization mismatch");
     // Verify deserialization works by checking it produces the same serialization
     let deserialize_ptr = 0;
     let deserialized = SimpleEnum::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     let reserialized = SimpleEnum::cairo_serialize(&deserialized);
-    assert_eq!(
-        serialized, reserialized,
-        "Enum roundtrip serialization failed"
-    );
+    assert_eq!(serialized, reserialized, "Enum roundtrip serialization failed");
 }
 
 #[test]
 fn test_result_err_u32() {
     let description = r#"Result with Err(u32)"#;
 
-    let expected_serialized = ["0x1", "0x1c8"];
+    let expected_serialized = [
+        "0x1",
+        "0x1c8",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -207,24 +107,21 @@ fn test_result_err_u32() {
     // Using built-in Result<Felt, u32> (equivalent to abigen!-generated type)
     let test_instance = Err::<Felt, u32>(456_u32);
     let serialized = Result::<Felt, u32>::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Result<Felt, u32> Err serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Result<Felt, u32> Err serialization mismatch");
     let deserialize_ptr = 0;
-    let deserialized =
-        Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Result<Felt, u32> Err roundtrip failed"
-    );
+    let deserialized = Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Result<Felt, u32> Err roundtrip failed");
 }
 
 #[test]
 fn test_byte_array() {
     let description = r#"ByteArray with string data"#;
 
-    let expected_serialized = ["0x0", "0x48656c6c6f2c20436169726f21", "0xd"];
+    let expected_serialized = [
+        "0x0",
+        "0x48656c6c6f2c20436169726f21",
+        "0xd",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -244,31 +141,23 @@ fn test_byte_array() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized =
-        cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    let deserialized = cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_option_some_felt() {
     let description = r#"Option with Some(felt252)"#;
 
-    let expected_serialized = ["0x0", "0x2a"];
+    let expected_serialized = [
+        "0x0",
+        "0x2a",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -284,23 +173,19 @@ fn test_option_some_felt() {
     // Using built-in Option<Felt> (equivalent to abigen!-generated type)
     let test_instance = Some(Felt::from_hex("0x2a").unwrap());
     let serialized = Option::<Felt>::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Option<Felt> Some serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Option<Felt> Some serialization mismatch");
     let deserialize_ptr = 0;
     let deserialized = Option::<Felt>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Option<Felt> Some roundtrip failed"
-    );
+    assert_eq!(test_instance, deserialized, "Option<Felt> Some roundtrip failed");
 }
 
 #[test]
 fn test_option_none_felt() {
     let description = r#"Option with None"#;
 
-    let expected_serialized = ["0x1"];
+    let expected_serialized = [
+        "0x1",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -316,23 +201,19 @@ fn test_option_none_felt() {
     // Using built-in Option<Felt> (equivalent to abigen!-generated type)
     let test_instance = None::<Felt>;
     let serialized = Option::<Felt>::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Option<Felt> None serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Option<Felt> None serialization mismatch");
     let deserialize_ptr = 0;
     let deserialized = Option::<Felt>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Option<Felt> None roundtrip failed"
-    );
+    assert_eq!(test_instance, deserialized, "Option<Felt> None roundtrip failed");
 }
 
 #[test]
 fn test_bool_false() {
     let description = r#"Boolean false value"#;
 
-    let expected_serialized = ["0x0"];
+    let expected_serialized = [
+        "0x0",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -348,10 +229,7 @@ fn test_bool_false() {
     // Using built-in bool (equivalent to abigen!-generated Bool)
     let test_instance = false;
     let serialized = bool::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Bool serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Bool serialization mismatch");
     let deserialize_ptr = 0;
     let deserialized = bool::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     assert_eq!(test_instance, deserialized, "Bool roundtrip failed");
@@ -361,7 +239,9 @@ fn test_bool_false() {
 fn test_u32() {
     let description = r#"Maximum u32 value"#;
 
-    let expected_serialized = ["0xffffffff"];
+    let expected_serialized = [
+        "0xffffffff",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -381,30 +261,23 @@ fn test_u32() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u32::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_tuple_felt_u32() {
     let description = r#"Tuple of felt252 and u32"#;
 
-    let expected_serialized = ["0x7b", "0x1c8"];
+    let expected_serialized = [
+        "0x7b",
+        "0x1c8",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -424,23 +297,13 @@ fn test_tuple_felt_u32() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = <(Felt, u32)>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
@@ -462,10 +325,7 @@ fn test_u256_large() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = cainome_cairo_serde::U256 {
-        low: 0xffffffffffffffffffffffffffffffff_u128,
-        high: 0x123456789abcdef123456789abcdef12_u128,
-    };
+    let test_instance = cainome_cairo_serde::U256 { low: 0xffffffffffffffffffffffffffffffff_u128, high: 0x123456789abcdef123456789abcdef12_u128 };
 
     // Test serialization
     let serialized = cainome_cairo_serde::U256::cairo_serialize(&test_instance);
@@ -473,31 +333,22 @@ fn test_u256_large() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized =
-        cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    let deserialized = cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_u64() {
     let description = r#"Maximum u64 value"#;
 
-    let expected_serialized = ["0xffffffffffffffff"];
+    let expected_serialized = [
+        "0xffffffffffffffff",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -517,30 +368,22 @@ fn test_u64() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u64::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_bool_true() {
     let description = r#"Boolean true value"#;
 
-    let expected_serialized = ["0x1"];
+    let expected_serialized = [
+        "0x1",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -556,10 +399,7 @@ fn test_bool_true() {
     // Using built-in bool (equivalent to abigen!-generated Bool)
     let test_instance = true;
     let serialized = bool::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Bool serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Bool serialization mismatch");
     let deserialize_ptr = 0;
     let deserialized = bool::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     assert_eq!(test_instance, deserialized, "Bool roundtrip failed");
@@ -569,7 +409,10 @@ fn test_bool_true() {
 fn test_mixed_enum_variant1() {
     let description = r#"MixedEnum with felt252 variant"#;
 
-    let expected_serialized = ["0x0", "0x789"];
+    let expected_serialized = [
+        "0x0",
+        "0x789",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -586,25 +429,21 @@ fn test_mixed_enum_variant1() {
     // Using actual abigen!-generated enum type with data
     let test_instance = MixedEnum::Variant1(Felt::from_hex("0x789").unwrap());
     let serialized = MixedEnum::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Enum serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Enum serialization mismatch");
     // Verify deserialization works by checking it produces the same serialization
     let deserialize_ptr = 0;
     let deserialized = MixedEnum::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
     let reserialized = MixedEnum::cairo_serialize(&deserialized);
-    assert_eq!(
-        serialized, reserialized,
-        "Enum roundtrip serialization failed"
-    );
+    assert_eq!(serialized, reserialized, "Enum roundtrip serialization failed");
 }
 
 #[test]
 fn test_felt252() {
     let description = r#"Basic felt252 value"#;
 
-    let expected_serialized = ["0x1234567890abcdef"];
+    let expected_serialized = [
+        "0x1234567890abcdef",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -624,30 +463,23 @@ fn test_felt252() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = Felt::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_u256() {
     let description = r#"U256 struct with low and high fields"#;
 
-    let expected_serialized = ["0x123456789abcdef123456789abcdef12", "0x0"];
+    let expected_serialized = [
+        "0x123456789abcdef123456789abcdef12",
+        "0x0",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -659,10 +491,7 @@ fn test_u256() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = cainome_cairo_serde::U256 {
-        low: 0x123456789abcdef123456789abcdef12_u128,
-        high: 0_u128,
-    };
+    let test_instance = cainome_cairo_serde::U256 { low: 0x123456789abcdef123456789abcdef12_u128, high: 0_u128 };
 
     // Test serialization
     let serialized = cainome_cairo_serde::U256::cairo_serialize(&test_instance);
@@ -670,31 +499,22 @@ fn test_u256() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized =
-        cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    let deserialized = cainome_cairo_serde::U256::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_u128() {
     let description = r#"Large u128 value"#;
 
-    let expected_serialized = ["0x112210f47de98115"];
+    let expected_serialized = [
+        "0x112210f47de98115",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -714,23 +534,13 @@ fn test_u128() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u128::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
@@ -771,10 +581,7 @@ fn test_struct_with_struct() {
     let test_instance = StructWithStruct::cairo_deserialize(&expected_felt_values, 0).unwrap();
     // Test serialization using abigen!-generated type (tests serialization)
     let serialized = StructWithStruct::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Struct round-trip serialization failed"
-    );
+    assert_eq!(serialized, expected_felt_values, "Struct round-trip serialization failed");
     // Verify we can deserialize again (double round-trip)
     let deserialized_again = StructWithStruct::cairo_deserialize(&serialized, 0).unwrap();
     let reserialized = StructWithStruct::cairo_serialize(&deserialized_again);
@@ -785,7 +592,9 @@ fn test_struct_with_struct() {
 fn test_u8() {
     let description = r#"Maximum u8 value"#;
 
-    let expected_serialized = ["0xff"];
+    let expected_serialized = [
+        "0xff",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -805,30 +614,24 @@ fn test_u8() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = u8::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_byte_array_empty() {
     let description = r#"Empty ByteArray"#;
 
-    let expected_serialized = ["0x0", "0x0", "0x0"];
+    let expected_serialized = [
+        "0x0",
+        "0x0",
+        "0x0",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -848,31 +651,23 @@ fn test_byte_array_empty() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized =
-        cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    let deserialized = cainome_cairo_serde::ByteArray::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_result_ok_felt() {
     let description = r#"Result with Ok(felt252)"#;
 
-    let expected_serialized = ["0x0", "0x7b"];
+    let expected_serialized = [
+        "0x0",
+        "0x7b",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -888,24 +683,19 @@ fn test_result_ok_felt() {
     // Using built-in Result<Felt, u32> (equivalent to abigen!-generated type)
     let test_instance = Ok::<Felt, u32>(Felt::from_hex("0x7b").unwrap());
     let serialized = Result::<Felt, u32>::cairo_serialize(&test_instance);
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Result<Felt, u32> Ok serialization mismatch"
-    );
+    assert_eq!(serialized, expected_felt_values, "Result<Felt, u32> Ok serialization mismatch");
     let deserialize_ptr = 0;
-    let deserialized =
-        Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Result<Felt, u32> Ok roundtrip failed"
-    );
+    let deserialized = Result::<Felt, u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Result<Felt, u32> Ok roundtrip failed");
 }
 
 #[test]
 fn test_eth_address() {
     let description = r#"EthAddress value"#;
 
-    let expected_serialized = ["0x1234567890abcdef1234567890abcdef12345678"];
+    let expected_serialized = [
+        "0x1234567890abcdef1234567890abcdef12345678",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -917,9 +707,7 @@ fn test_eth_address() {
 
     // Direct cairo-serde roundtrip test using test artifact data
     // Using actual test data from artifact
-    let test_instance = cainome_cairo_serde::EthAddress::from(
-        Felt::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap(),
-    );
+    let test_instance = cainome_cairo_serde::EthAddress::from(Felt::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap());
 
     // Test serialization
     let serialized = cainome_cairo_serde::EthAddress::cairo_serialize(&test_instance);
@@ -927,31 +715,25 @@ fn test_eth_address() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
-    let deserialized =
-        cainome_cairo_serde::EthAddress::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    let deserialized = cainome_cairo_serde::EthAddress::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
 
 #[test]
 fn test_array_u32() {
     let description = r#"Array of u32 values"#;
 
-    let expected_serialized = ["0x3", "0x1", "0x2", "0x3"];
+    let expected_serialized = [
+        "0x3",
+        "0x1",
+        "0x2",
+        "0x3",
+    ];
 
     let expected_felt_values: Vec<Felt> = expected_serialized
         .iter()
@@ -971,21 +753,12 @@ fn test_array_u32() {
     println!("Actual:   {:?}", serialized);
 
     // Verify serialization matches expected
-    assert_eq!(
-        serialized.len(),
-        expected_felt_values.len(),
-        "Serialized length mismatch"
-    );
-    assert_eq!(
-        serialized, expected_felt_values,
-        "Serialized values mismatch"
-    );
+    assert_eq!(serialized.len(), expected_felt_values.len(), "Serialized length mismatch");
+    assert_eq!(serialized, expected_felt_values, "Serialized values mismatch");
 
     // Test roundtrip deserialization
     let deserialize_ptr = 0;
     let deserialized = Vec::<u32>::cairo_deserialize(&serialized, deserialize_ptr).unwrap();
-    assert_eq!(
-        test_instance, deserialized,
-        "Roundtrip deserialization failed"
-    );
+    assert_eq!(test_instance, deserialized, "Roundtrip deserialization failed");
 }
+


### PR DESCRIPTION
Closes #112.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `to_string_lossy` and `to_bytes` to `ByteArray`, plus a lossy UTF-8 helper and tests.
> 
> - **ByteArray API**:
>   - Add `to_string_lossy()` for lossy UTF-8 decoding across `data` and `pending_word`.
>   - Add `to_bytes()` to extract raw bytes from `data` and `pending_word`.
> - **Internal**:
>   - Implement `felt_to_utf8_lossy()` helper.
> - **Tests**:
>   - Add round-trip and edge-case tests for `to_bytes()`.
>   - Add validity/invalidity, empty, emoji, and mixed `data`+`pending` tests for `to_string_lossy()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9ca49b050d2b6b71221a3071669a0de460dce75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->